### PR TITLE
uitbrijden pipeline regels

### DIFF
--- a/.github/workflows/maui-tests.yml
+++ b/.github/workflows/maui-tests.yml
@@ -4,14 +4,20 @@ on:
   push:
     branches:
       - main
+      - dev
+      - feature/*
+      - hotfix/*
+      - release/*
       - infra/runner-toevoegen
   pull_request:
     branches:
       - main
+      - dev
+      - release/* 
  
 jobs:
   test:
-    runs-on: ubuntu-latest  # Of windows-latest/macOS-latest als specifiek platform nodig is
+    runs-on: windows-latest  # Of windows-latest/macOS-latest als specifiek platform nodig is
     steps:
       - name: Haal de repository op
         uses: actions/checkout@v4
@@ -19,7 +25,7 @@ jobs:
       - name: Installeer .NET SDK
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '8.0.x'  # Gebruik de juiste versie voor MAUI
+          dotnet-version: '9.0.304'  # Gebruik de juiste versie voor MAUI
  
       - name: Installeer MAUI workloads
         run: dotnet workload install maui-android


### PR DESCRIPTION
- meer branches
- andere os
- nieuwere dotnet

heb ingesteld dat de pipeline bij elke branch nu aan gaat. de dotnet versie is aangepast naar waar ik op ontwikkel. de test word nu geruned op de windows build i.p.v. ubuntu.